### PR TITLE
Feature/xivy 5007 docusign

### DIFF
--- a/market/connector/Jenkinsfile
+++ b/market/connector/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
   stages {
     stage('build') {
       steps {
-          dir('market/connector/uipath/demo'){
+          dir('market/connector'){
               script {
                 def mavenParameters = "-Divy.engine.list.url=${params.engineListUrl} " +
                   "-Divy.engine.version=[9.2.0,] -Dmaven.test.failure.ignore=true "

--- a/market/connector/docusign/README.md
+++ b/market/connector/docusign/README.md
@@ -15,3 +15,4 @@ Integrate eSignatures into your application in minutes. DocuSign's secure and aw
 1. Scroll to the **Additional settings** section and add the `Redirect URI` from the Rest Clients property `AUTH.callback` into the docusign admin frontend.
 ![integration-key](doc/images/configureRedirectUri.png)
 1. Save the changed application settings.
+

--- a/market/connector/docusign/demo/eSignatureDemo/processes/start.mod
+++ b/market/connector/docusign/demo/eSignatureDemo/processes/start.mod
@@ -107,7 +107,7 @@ user_name=;
 ' #txt
 st0 f6 templateParams 'accountId="placeholder";
 ' #txt
-st0 f6 resultType com.docusign.esignature.EnvelopesInformation #txt
+st0 f6 resultType net.docusign.esignature.EnvelopesInformation #txt
 st0 f6 responseMapping 'out.envelopes=result.envelopes;
 ' #txt
 st0 f6 clientErrorCode ivy:error:rest:client #txt

--- a/market/connector/docusign/demo/eSignatureDemo/restClients.restConfig
+++ b/market/connector/docusign/demo/eSignatureDemo/restClients.restConfig
@@ -54,7 +54,7 @@
                 </property>
                 <property>
                     <name>AUTH.baseUri</name>
-                    <value>http://localhost:8081/designer/api/docuSignMock/oauth</value>
+                    <value>http://{ivy.engine.host}:{ivy.engine.http.port}/{ivy.request.application}/api/docuSignMock/oauth</value>
                     <password>false</password>
                 </property>
                 <feature>

--- a/market/connector/docusign/demo/eSignatureDemoTest/src/net/docusign/test/DocuSignOAuthMock.java
+++ b/market/connector/docusign/demo/eSignatureDemoTest/src/net/docusign/test/DocuSignOAuthMock.java
@@ -19,6 +19,7 @@ import javax.ws.rs.core.UriBuilder;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 
+import ch.ivyteam.ivy.application.IApplication;
 import io.swagger.v3.oas.annotations.Hidden;
 
 @Path("docuSignMock/oauth")
@@ -54,7 +55,7 @@ public class DocuSignOAuthMock
     String info = load("json/userinfo.json");
     URI myUri = ch.ivyteam.ivy.request.EngineUriResolver.instance().local();
     info = StringUtils.replace(info, "http://localhost:!port!/mock", 
-        myUri.toASCIIString()+"/designer/api/docuSignMock");
+        myUri.toASCIIString()+"/"+IApplication.current().getName()+"/api/docuSignMock");
     return info;
   }
   

--- a/market/connector/pom.xml
+++ b/market/connector/pom.xml
@@ -1,0 +1,13 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>ch.ivyteam.ivy.market</groupId>
+  <artifactId>connector.modules</artifactId>
+  <version>9.2.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>uipath/demo</module>
+    <module>docusign/demo</module>
+  </modules>
+</project>


### PR DESCRIPTION
converted existing 'uipath' build to a generic connector build -> https://jenkins.ivyteam.io/job/market-connectors/

make sense for me at this time:
- the large p2 base has only to be downloaded once if we run it all in one maven reactor run.
- I do not have to introduce and maintain a single 'Jenkinsfile' pipeline for each and every connector.

however, maybe somewhen later we can still introduce custom builds for only one connector.