### PR TITLE
Rename costs to cost

### DIFF
--- a/market-test/src/test/java/com/axonivy/market/test/ValidateRepoTest.java
+++ b/market-test/src/test/java/com/axonivy/market/test/ValidateRepoTest.java
@@ -36,7 +36,7 @@ class ValidateRepoTest
             .optionalStringPropertyWithPattern("compatibility", "^(\\d+\\.)?(\\d+\\.)?(\\*|\\d+)[+]?$")
             .optionalStringPropertyWithPattern("platformReview", "^([0-4])?(\\.[5])?$|^5$")
             .optionalStringPropertyWithMinLength("industry", 2)
-            .optionalStringPropertyWithFixedValues("costs", "paid") // free is default            
+            .optionalStringPropertyWithFixedValues("cost", "paid") // free is default            
             .requireStringPropertyWithFixedValues("type", "connector", "solution", "process", "util")
             .optionalBooleanProperty("listed", true)
             .optionalStringPropertyWithFixedValues("versionDisplay", "portal", "hide-snapshots")

--- a/market/solutions/employee-onboarding/meta.json
+++ b/market/solutions/employee-onboarding/meta.json
@@ -5,7 +5,7 @@
 	"description": "This solution helps HR managers to accelerate time-to-market for employee onboarding.",
 	"type": "solution",
 	"vendor": "Axon Ivy AG",
-	"costs": "paid",
+	"cost": "paid",
 	"language": "EN",
 	"industry": "Cross-Industry",
 	"tags": ["hr"]


### PR DESCRIPTION
Cost is the correct spelling. Reported by Peter Hochstrasser